### PR TITLE
Memory fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,11 @@ CFLAGS = -g -lm
 all: clean module
 
 module:
-	$(CC) -i -a -c `pkg-config --cflags --libs jansson openssl libcurl` -lm src/mod_perimeterx.c src/perimeterx.c src/cookie_decoder.c src/http_util.c src/json_util.c 
+	$(CC) -i -a -Wc,-std=gnu99 -c `pkg-config --cflags --libs jansson openssl libcurl` -lm src/mod_perimeterx.c src/perimeterx.c src/cookie_decoder.c src/http_util.c src/json_util.c 
 
 clean:
-	rm -rf *.o
-	rm -rf *.out
+	rm -rf src/*.o
+	rm -rf src/*.out
+	rm -rf src/*.lo
+	rm -rf src/*.slo
+	rm -rf src/*.la

--- a/src/http_util.c
+++ b/src/http_util.c
@@ -84,7 +84,6 @@ char *do_request(const char *url, const char *payload, const char *auth_header, 
     if (res == CURLE_OK) {
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
         if (status_code == 200) {
-            free(response.data);
             return response.data;
         }
 

--- a/src/http_util.c
+++ b/src/http_util.c
@@ -80,6 +80,9 @@ char *do_request(const char *url, const char *payload, const char *auth_header, 
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_response_cb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*) &response);
     res = curl_easy_perform(curl);
+
+    curl_slist_free_all(headers);
+
     if (res == CURLE_OK) {
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
         if (status_code == 200) {

--- a/src/http_util.c
+++ b/src/http_util.c
@@ -80,9 +80,11 @@ char *do_request(const char *url, const char *payload, const char *auth_header, 
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_response_cb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*) &response);
     res = curl_easy_perform(curl);
+    curl_slist_free_all(headers);
     if (res == CURLE_OK) {
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
         if (status_code == 200) {
+            free(response.data);
             return response.data;
         }
 
@@ -90,6 +92,7 @@ char *do_request(const char *url, const char *payload, const char *auth_header, 
     } else {
         ERROR(r->server, "curl_easy_perform() failed: %s", curl_easy_strerror(res));
     }
+
     free(response.data);
     return NULL;
 }

--- a/src/http_util.c
+++ b/src/http_util.c
@@ -80,18 +80,16 @@ char *do_request(const char *url, const char *payload, const char *auth_header, 
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_response_cb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*) &response);
     res = curl_easy_perform(curl);
-
-    curl_slist_free_all(headers);
-
     if (res == CURLE_OK) {
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
         if (status_code == 200) {
             return response.data;
         }
-        free(response.data);
+
         ERROR(r->server, "PX server request returned status: %ld, url: %s", status_code, response.data);
     } else {
         ERROR(r->server, "curl_easy_perform() failed: %s", curl_easy_strerror(res));
     }
+    free(response.data);
     return NULL;
 }

--- a/src/json_util.c
+++ b/src/json_util.c
@@ -2,10 +2,10 @@
 #include <jansson_config.h>
 
 #include "json_util.h"
+#include "apr_strings.h"
 
 json_t *header_to_json(const char *key, const char *value);
 json_t *headers_to_json(const apr_array_header_t *arr);
-void free_headers_json(json_t *j_headers);
 
 static const char *s2s_call_reason_string(s2s_call_reason_t r) {
     static const char *call_reasons[] = { "none", "no_cookie", "expired_cookie", "invalid_cookie"};
@@ -142,10 +142,10 @@ captcha_response *parse_captcha_response(char* captcha_response_str, const reque
     json_t *j_vid = json_object_get(j_response, "vid");
     json_t *j_cid = json_object_get(j_response, "cid");
 
-    parsed_response->uuid = json_string_value(j_uuid);
+    parsed_response->uuid = apr_pstrdup(ctx->r->pool, json_string_value(j_uuid));
     parsed_response->status = json_integer_value(j_status);
-    parsed_response->vid = json_string_value(j_vid);
-    parsed_response->cid = json_string_value(j_cid);
+    parsed_response->vid = apr_pstrdup(ctx->r->pool, json_string_value(j_vid));
+    parsed_response->cid = apr_pstrdup(ctx->r->pool, json_string_value(j_cid));
 
     json_decref(j_response);
 
@@ -165,7 +165,7 @@ risk_response* parse_risk_response(char* risk_response_str, const request_contex
     json_t *j_scores = json_object_get(j_response, "scores");
     json_t *j_non_human = json_object_get(j_scores, "non_human");
 
-    parsed_response->uuid = json_string_value(j_uuid);
+    parsed_response->uuid = apr_pstrdup(ctx->r->pool, json_string_value(j_uuid));
     parsed_response->status = json_integer_value(j_status);
     parsed_response->score = json_integer_value(j_non_human);
 

--- a/src/json_util.c
+++ b/src/json_util.c
@@ -170,10 +170,6 @@ risk_response* parse_risk_response(char* risk_response_str, const request_contex
     parsed_response->score = json_integer_value(j_non_human);
 
     json_decref(j_response);
-    json_decref(j_non_human);
-    json_decref(j_scores);
-    json_decref(j_status);
-    json_decref(j_uuid);
 
     return parsed_response;
 }

--- a/src/json_util.c
+++ b/src/json_util.c
@@ -25,38 +25,26 @@ char *create_captcha_payload(const request_context *ctx, px_config *conf) {
     const apr_array_header_t *header_arr = apr_table_elts(ctx->headers);
     json_t *j_headers = headers_to_json(header_arr);
     json_object_set(request, "headers", j_headers);
-    json_object_set(root, "request", request);
+    json_object_set_new(root, "request", request);
 
     if (ctx->vid) {
         j_vid = json_string(ctx->vid);
-        json_object_set(root, "vid", j_vid);
+        json_object_set_new(root, "vid", j_vid);
     }
     if (ctx->px_captcha) {
         j_pxcaptcha = json_string(ctx->px_captcha);
-        json_object_set(root, "pxCaptcha", j_pxcaptcha);
+        json_object_set_new(root, "pxCaptcha", j_pxcaptcha);
     }
     if (ctx->hostname) {
         j_hostname = json_string(ctx->hostname);
-        json_object_set(root, "hostname", j_hostname);
+        json_object_set_new(root, "hostname", j_hostname);
     }
 
     char *payload = json_dumps(root, JSON_ENCODE_ANY);
 
-    if (j_vid) {
-        json_decref(j_vid);
-
-    }
-    if (j_hostname) {
-        json_decref(j_hostname);
-    }
-    if (j_pxcaptcha) {
-        json_decref(j_pxcaptcha);
-    }
-
     json_decref(root);
-    free_headers_json(j_headers);
+    json_array_clear(j_headers);
     json_decref(j_headers);
-    json_decref(request);
 
     return payload;
 }
@@ -74,7 +62,7 @@ char *create_risk_payload(const request_context *ctx, const px_config *conf, boo
 
     if (cookie_expired && ctx->uuid) {
         j_uuid = json_string(ctx->uuid);
-        json_object_set(request, "uuid", j_uuid);
+        json_object_set_new(request, "uuid", j_uuid);
     }
 
     j_additional = json_pack("{s:s, s:s, s:s, s:s}", "s2s_call_reason", s2s_call_reason_string(ctx->call_reason), "http_method", ctx->http_method, "http_version", ctx->http_version, "module_version", conf->module_version);
@@ -91,17 +79,7 @@ char *create_risk_payload(const request_context *ctx, const px_config *conf, boo
 
     char *request_str = json_dumps(request, JSON_ENCODE_ANY);
 
-    if (j_uuid) {
-        json_decref(j_uuid);
-    }
-    if (j_vid) {
-        json_decref(j_vid);
-    }
-    if (j_px_cookie) {
-        json_decref(j_px_cookie);
-    }
-
-    free_headers_json(j_headers);
+    json_array_clear(j_headers);
     json_decref(j_headers);
     json_decref(j_data);
     json_decref(j_additional);
@@ -120,17 +98,17 @@ char *create_activity(const char *activity_type, px_config *conf, request_contex
 
     if (ctx->vid) {
         j_vid = json_string(ctx->vid);
-        json_object_set(activity, "vid", j_vid);
+        json_object_set_new(activity, "vid", j_vid);
     }
 
     json_t *details = json_pack("{s:i, s:s, s:s, s:s, s:s}", "block_score", ctx->score, "block_reason", block_reason_string(ctx->block_reason), "http_method", ctx->http_method, "http_version", ctx->http_version, "module_version", conf->module_version);
 
     if (activity_type == "block" && ctx->uuid) {
         j_uuid = json_string(ctx->uuid);
-        json_object_set(details, "block_uuid", j_uuid);
+        json_object_set_new(details, "block_uuid", j_uuid);
     }
 
-    json_object_set(activity, "details", details);
+    json_object_set_new(activity, "details", details);
 
     j_headers = json_object();
     void **ptrs = apr_palloc(ctx->r->pool, sizeof(void*) *header_arr->nelts);
@@ -139,27 +117,15 @@ char *create_activity(const char *activity_type, px_config *conf, request_contex
     for (i = 0; i < header_arr->nelts; i++) {
         h = APR_ARRAY_IDX(header_arr, i, apr_table_entry_t);
         json_t *j_header = json_string(h.val);
-        json_object_set(j_headers, h.key, j_header);
-        ptrs[i] = j_header;
+        json_object_set_new(j_headers, h.key, j_header);
     }
 
     header_arr = apr_table_elts(ctx->headers);
     json_object_set(activity, "headers", j_headers);
     char *request_str = json_dumps(activity, JSON_ENCODE_ANY);
 
-    if (j_vid) {
-        json_decref(j_vid);
-    }
-    if (j_uuid) {
-        json_decref(j_uuid);
-    }
-    for (i = 0; i < header_arr->nelts; i++) {
-        json_decref(ptrs[i]);
-    }
-    
-    free_headers_json(j_headers);
+    json_array_clear(j_headers);
     json_decref(j_headers);
-    json_decref(details);
     json_decref(activity);
     return request_str;
 }
@@ -216,10 +182,8 @@ json_t *header_to_json(const char *key, const char *value) {
     json_t *h = json_object();
     json_t *j_key = json_string(key);
     json_t *j_value = json_string(value);
-    json_object_set(h, "name", j_key);
-    json_object_set(h, "value", j_value);
-    json_decref(j_key);
-    json_decref(j_value);
+    json_object_set_new(h, "name", j_key);
+    json_object_set_new(h, "value", j_value);
     return h;
 }
 
@@ -234,21 +198,8 @@ json_t *headers_to_json(const apr_array_header_t *arr) {
     for (i = 0; i < arr->nelts; i++) {
         h = APR_ARRAY_IDX(arr, i, apr_table_entry_t);
         j_header = header_to_json(h.key, h.val);
-        json_array_append(j_headers, j_header);
+        json_array_append_new(j_headers, j_header);
     }
-    
-    json_decref(j_header);
 
     return j_headers;
 }
-
-void free_headers_json(json_t *j_headers) {
-    size_t index;
-    json_t *value;
-
-    // Free all headers
-    json_array_foreach(j_headers, index, value) {
-        json_decref(value);
-    }
-}
-

--- a/src/json_util.c
+++ b/src/json_util.c
@@ -43,19 +43,20 @@ char *create_captcha_payload(const request_context *ctx, px_config *conf) {
     char *payload = json_dumps(root, JSON_ENCODE_ANY);
 
     if (j_vid) {
-        free(j_vid);
+        json_decref(j_vid);
+
     }
     if (j_hostname) {
-        free(j_hostname);
+        json_decref(j_hostname);
     }
     if (j_pxcaptcha) {
-        free(j_pxcaptcha);
+        json_decref(j_pxcaptcha);
     }
 
-    free(root);
+    json_decref(root);
     free_headers_json(j_headers);
-    free(j_headers);
-    free(request);
+    json_decref(j_headers);
+    json_decref(request);
 
     return payload;
 }
@@ -91,20 +92,20 @@ char *create_risk_payload(const request_context *ctx, const px_config *conf, boo
     char *request_str = json_dumps(request, JSON_ENCODE_ANY);
 
     if (j_uuid) {
-        free(j_uuid);
+        json_decref(j_uuid);
     }
     if (j_vid) {
-        free(j_vid);
+        json_decref(j_vid);
     }
     if (j_px_cookie) {
-        free(j_px_cookie);
+        json_decref(j_px_cookie);
     }
 
     free_headers_json(j_headers);
-    free(j_headers);
-    free(j_data);
-    free(j_additional);
-    free(request);
+    json_decref(j_headers);
+    json_decref(j_data);
+    json_decref(j_additional);
+    json_decref(request);
 
     return request_str;
 }
@@ -147,17 +148,19 @@ char *create_activity(const char *activity_type, px_config *conf, request_contex
     char *request_str = json_dumps(activity, JSON_ENCODE_ANY);
 
     if (j_vid) {
-        free(j_vid);
+        json_decref(j_vid);
     }
     if (j_uuid) {
-        free(j_uuid);
+        json_decref(j_uuid);
     }
     for (i = 0; i < header_arr->nelts; i++) {
-        free(ptrs[i]);
+        json_decref(ptrs[i]);
     }
-    free(j_headers);
-    free(details);
-    free(activity);
+    
+    free_headers_json(j_headers);
+    json_decref(j_headers);
+    json_decref(details);
+    json_decref(activity);
     return request_str;
 }
 
@@ -177,6 +180,8 @@ captcha_response *parse_captcha_response(char* captcha_response_str, const reque
     parsed_response->status = json_integer_value(j_status);
     parsed_response->vid = json_string_value(j_vid);
     parsed_response->cid = json_string_value(j_cid);
+
+    json_decref(j_response);
 
     return parsed_response;
 }
@@ -198,11 +203,11 @@ risk_response* parse_risk_response(char* risk_response_str, const request_contex
     parsed_response->status = json_integer_value(j_status);
     parsed_response->score = json_integer_value(j_non_human);
 
-    free(j_response);
-    free(j_non_human);
-    free(j_scores);
-    free(j_status);
-    free(j_uuid);
+    json_decref(j_response);
+    json_decref(j_non_human);
+    json_decref(j_scores);
+    json_decref(j_status);
+    json_decref(j_uuid);
 
     return parsed_response;
 }
@@ -213,6 +218,8 @@ json_t *header_to_json(const char *key, const char *value) {
     json_t *j_value = json_string(value);
     json_object_set(h, "name", j_key);
     json_object_set(h, "value", j_value);
+    json_decref(j_key);
+    json_decref(j_value);
     return h;
 }
 
@@ -229,6 +236,8 @@ json_t *headers_to_json(const apr_array_header_t *arr) {
         j_header = header_to_json(h.key, h.val);
         json_array_append(j_headers, j_header);
     }
+    
+    json_decref(j_header);
 
     return j_headers;
 }
@@ -239,7 +248,7 @@ void free_headers_json(json_t *j_headers) {
 
     // Free all headers
     json_array_foreach(j_headers, index, value) {
-        free(value);
+        json_decref(value);
     }
 }
 

--- a/src/perimeterx.c
+++ b/src/perimeterx.c
@@ -49,6 +49,8 @@ bool verify_captcha(request_context *ctx, px_config *conf) {
         free(response_str);
     }
 
+    free(payload);
+
     if (c) {
         captcha_verified = c->status == 0;
         if (!captcha_verified) {
@@ -151,6 +153,7 @@ risk_response* risk_api_get(const request_context *ctx, const px_config *conf, b
     INFO(ctx->r->server, "risk_api_get: server response (%s)", risk_response_str);
     risk_response *risk_response = parse_risk_response(risk_response_str, ctx);
     free(risk_response_str);
+    free(risk_payload);
     return risk_response;
 }
 
@@ -177,6 +180,7 @@ static void post_verification(request_context *ctx, px_config *conf, bool reques
             ERROR(ctx->r->server, "post_verification: (%s) send failed", activity_type);
         }
     }
+    free(activity);
 }
 
 static bool px_verify_request(request_context *ctx, px_config *conf) {


### PR DESCRIPTION
- free curl headers
- use json_decref
- free objects created from json_dumps

Test running:

valgrind -v --log-file=debug_memory.log --trace-children=yes --leak-check=full --show-reachable=no --tool=memcheck  /usr/local/apache2/bin/httpd  -k start -X
