### PR TITLE
Add .travis.yml with Coverity support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,30 @@
 sudo: required
-
-services:
-  - docker
-
+dist: trusty
+before_install:
+- sudo apt update
+- sudo apt install -y --no-install-recommends git ca-certificates libtool m4 autoconf
+  automake libjansson-dev libssl-dev libcurl4-openssl-dev apache2-dev apache2
+language: c
+compiler:
+- gcc
 script:
-  - docker build -t perimeterx/mod_perimeterx .
+- "./autogen.sh"
+- "./configure --enable-module --disable-silent-rules"
+- make clean
+- make
+- sudo make install
+- sudo cp perimeterx.conf /etc/apache2/mods-available/perimeterx.conf
+- sudo ln -s /etc/apache2/mods-available/perimeterx.conf /etc/apache2/mods-enabled/
+- sudo apachectl -f /etc/apache2/apache2.conf -e debug -DFOREGROUND -t
+env:
+  global:
+  # COVERITY_SCAN_TOKEN
+  - secure: J46JRoJtnk/En2FfFVs26VlisjBqsPNSBPiFKd85jOCE9mWh8nj/EByGRavdarT1yAC+QIVwbVSnptX6YJyDUkaj11DrMSxU1AeGaFYTsUMvtq7wdNHdV0GPtpeHlLAKMnbaZkrW2Y+sf+mjdrOj0rhiJm+7ZbDUoomWxF5GQzruaGTqtPDuEWfFDqKkYLu9uiWdkRzn1bWtL7ls+XRnqjSFMQGfgj+GaS+VVE/PxrK9gUKF2ZiM+Bj9azIGtHHUnQyotqAUw6fSYTQbJUuigPQE6M/MLwUxYB7vQE5boceni8km1CSxAJPG9qMSiVPpihsWNuF0ybFQeCQ4X1e0gmQ7UwQ7UdSak18IXrwEIohXF+ZGG45oJ8ejC9bHjb+oO3wLN0rsfHRYDoN5N7VTU2g1zqDgsR2xm1IR6pasxvipC3SwKARWxxU7haVix5HIN7REHfY+o71DY/2ZNKLB+gzd1UL1WIqNVB5czhHwLlVGXp1Cjeakm9EekuAekeAgfXLNThp8Kb8QnYRq+/PKnC/YTtRdb6CNRY05uPbkbRKe619nWluUX/WiZ+SxzO8dC1ta7ximiGgavl2jUfx92aPo+h+6hw7eVK9E42Ejg8MpkrQy0xxHK79Tlevhqf4CpfqqfaZtsYnf1G+cVxisjkse+6LQ9urLBOVbop5+iDw=
+addons:
+  coverity_scan:
+    project:
+      name: PerimeterX/mod_perimeterx
+      description: PerimeterX Apache Module
+    build_command_prepend: "./autogen.sh && ./configure && make clean"
+    build_command: make
+    branch_pattern: master


### PR DESCRIPTION
Changed TravisCI configuration to use native commands (instead of Docker) to install and build the project. A "build" considered successful if TravisCI has successfully built and installed module, and Apache configuration check returned Ok.
With this .travis.xml changes we can use TravisCI addon to send builds to Coverity static analyzer (from "master" branch only, due a limited number of scans per week). 