### PR TITLE
Json memleak (debug code only)

### DIFF
--- a/src/px_json.c
+++ b/src/px_json.c
@@ -376,7 +376,7 @@ const char* context_to_json_string(request_context *ctx) {
     if (header_arr) {
         for (int i = 0; i < header_arr->nelts; i++) {
             apr_table_entry_t h = APR_ARRAY_IDX(header_arr, i, apr_table_entry_t);
-            json_object_set(headers, h.key, json_string(h.val));
+            json_object_set_new(headers, h.key, json_string(h.val));
         }
     }
 


### PR DESCRIPTION
```json_object_set()``` function increases ref count by the ```value``` parameter.
It's safer to use ```json_object_set_new()``` which automatically decreases ref count and releases the memory of ```value``` parameter.