### PR TITLE
Do not handle requests if the module is disabled or not properly configured

### DIFF
--- a/src/mod_perimeterx.c
+++ b/src/mod_perimeterx.c
@@ -223,8 +223,8 @@ static void redirect_copy_headers_out(request_rec *r, const redirect_response *r
 }
 
 int px_handle_request(request_rec *r, px_config *conf) {
-    // Decline if module is disabled
-    if (!conf->module_enabled) {
+    // Decline if module is disabled or not properly configured
+    if (!conf || !conf->module_enabled || !conf->app_id) {
         return DECLINED;
     }
 
@@ -241,7 +241,7 @@ int px_handle_request(request_rec *r, px_config *conf) {
 
     const redirect_response *redirect_res = NULL;
     // Redirect client
-    if (strncmp(conf->client_path_prefix, r->parsed_uri.path, strlen(conf->client_path_prefix)) == 0) {
+    if (conf->client_path_prefix && strncmp(conf->client_path_prefix, r->parsed_uri.path, strlen(conf->client_path_prefix)) == 0) {
         redirect_res = redirect_client(r, conf);
         r->status = HTTP_OK;
         redirect_copy_headers_out(r, redirect_res);
@@ -250,7 +250,7 @@ int px_handle_request(request_rec *r, px_config *conf) {
     }
 
     // Redirect XHR
-    if (strncmp(conf->xhr_path_prefix, r->parsed_uri.path, strlen(conf->xhr_path_prefix)) == 0) {
+    if (conf->xhr_path_prefix && strncmp(conf->xhr_path_prefix, r->parsed_uri.path, strlen(conf->xhr_path_prefix)) == 0) {
         redirect_res = redirect_xhr(r, conf);
         r->status = HTTP_OK;
         redirect_copy_headers_out(r, redirect_res);
@@ -504,7 +504,7 @@ static apr_status_t px_child_setup(apr_pool_t *p, server_rec *s) {
 
         px_config *cfg = ap_get_module_config(vs->module_config, &perimeterx_module);
         if (!cfg || !cfg->module_enabled) {
-            ap_log_error(APLOG_MARK, APLOG_DEBUG | APLOG_NOERRNO, 0, s, LOGGER_DEBUG_FORMAT, cfg->app_id, "Request will not be verified, module is disabled");
+            ap_log_error(APLOG_MARK, APLOG_DEBUG | APLOG_NOERRNO, 0, s, LOGGER_DEBUG_FORMAT, cfg->app_id, "Request will not be verified, module is disabled or not properly configured");
             continue;
         }
         // initialize the PerimeterX needed pools and background workers if the PerimeterX module is enabled
@@ -642,7 +642,7 @@ static const char *set_app_id(cmd_parms *cmd, void *config, const char *app_id) 
     if (!conf) {
         return ERROR_CONFIG_MISSING;
     }
-    if (conf->base_url_is_set){
+    if (conf->base_url_is_set) {
         return ERROR_BASE_URL_BEFORE_APP_ID;
     }
     if (strlen(app_id) < 3) {
@@ -1155,8 +1155,12 @@ static void *create_config(apr_pool_t *p) {
         conf->risk_api_url = apr_pstrcat(p, conf->base_url, RISK_API, NULL);
         conf->captcha_api_url = apr_pstrcat(p, conf->base_url, CAPTCHA_API, NULL);
         conf->activities_api_url = apr_pstrcat(p, conf->base_url, ACTIVITIES_API, NULL);
-        conf->auth_token = "";
-        conf->auth_header = "";
+        conf->app_id = NULL;
+        conf->payload_key = NULL;
+        conf->auth_token = NULL;
+        conf->auth_header = NULL;
+        conf->client_path_prefix = NULL;
+        conf->xhr_path_prefix = NULL;
         conf->routes_whitelist = apr_array_make(p, 0, sizeof(char*));
         conf->useragents_whitelist = apr_array_make(p, 0, sizeof(char*));
         conf->custom_file_ext_whitelist = apr_array_make(p, 0, sizeof(char*));


### PR DESCRIPTION
Do not handle requests in ```ap_hook_post_read_request()``` hook if:
* module is not configured in vhost
* module is disabled (PXEnabled Off)
* module isn't properly configured (AppID is missing)

Fixes issue described in #141 