### PR TITLE
Minor code improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ build/packages/
 contrib/version.sh
 core
 valgrind.out
+compile_commands.json

--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,7 @@ AC_ARG_ENABLE(debug,
     AS_HELP_STRING([--enable-debug], [enable debug build]),
     [], [enable_debug=no])
 if test "x$enable_debug" = "xyes" ; then
-    CFLAGS="$CFLAGS -DDEBUG=1"
+    CFLAGS="$CFLAGS -DDEBUG=1 -Wall -Werror -Wextra -Waddress -Warray-bounds -Werror=array-bounds -Wmissing-noreturn -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Winline -Wformat-security -Wswitch-default -Winit-self -Wmissing-include-dirs -Wundef -Waggregate-return -Wmissing-format-attribute -Wnested-externs -Wformat=2 -Wunreachable-code -Wno-missing-field-initializers -Wno-format-nonliteral"
     AC_DEFINE([DEBUG], [1], [enable debug build])
 fi
 

--- a/src/mustach.c
+++ b/src/mustach.c
@@ -98,6 +98,7 @@ static int process(const char *template, struct mustach_itf *itf, void *closure,
 				template++;
 			}
 			c = '&';
+			/*@fallthrough@*/
 		case '^':
 		case '#':
 		case '/':

--- a/src/px_json.c
+++ b/src/px_json.c
@@ -64,7 +64,8 @@ const char *captcha_type_str(captcha_type_t captcha_type) {
 }
 
 // format json requests
-char *create_activity(const char *activity_type, const px_config *conf, const request_context *ctx) {
+char *create_activity(const char *activity_type, const request_context *ctx) {
+    px_config *conf = ctx->conf;
     json_t *j_details = json_pack("{s:i,s:s,s:s,s:s,s:s}",
             "block_score", ctx->score,
             "block_reason", BLOCK_REASON_STR[ctx->block_reason],
@@ -146,7 +147,8 @@ static json_t *headers_to_json_helper(const apr_array_header_t *arr) {
     return j_headers;
 }
 
-char *create_risk_payload(const request_context *ctx, const px_config *conf) {
+char *create_risk_payload(const request_context *ctx) {
+    px_config *conf = ctx->conf;
     // headers array
     const apr_array_header_t *header_arr = apr_table_elts(ctx->headers);
     json_t *j_headers = headers_to_json_helper(header_arr);
@@ -252,7 +254,8 @@ risk_response* parse_risk_response(const char* risk_response_str, const request_
     return parsed_response;
 }
 
-char *create_mobile_response(px_config *conf, request_context *ctx, const char *compiled_html) {
+char *create_mobile_response(request_context *ctx, const char *compiled_html) {
+    px_config *conf = ctx->conf;
     json_t *j_mobile_response = json_pack("{s:s,s:s,s:s,s:s}",
             "action", ACTION_STR[ctx->action],
             "appId", ctx->app_id,
@@ -272,7 +275,7 @@ char *create_mobile_response(px_config *conf, request_context *ctx, const char *
     return request_str;
 }
 
-char *create_json_response(px_config *conf, request_context *ctx) {
+char *create_json_response(request_context *ctx) {
     json_t *j_response = json_pack("{}");
 
     if (ctx->vid) {
@@ -423,7 +426,7 @@ const char* context_to_json_string(request_context *ctx) {
         json_object_set_new(ctx_json, "uuid", json_string(ctx->uuid));
     }
     if (ctx->px_payload) {
-        json_t *px_payloads = json_pack("{ ss }", "v1", ctx->px_payload);
+        px_payloads = json_pack("{ ss }", "v1", ctx->px_payload);
         json_object_set_new(ctx_json, "px_cookies", px_payloads);
     }
     if (ctx->px_payload_decrypted) {

--- a/src/px_json.h
+++ b/src/px_json.h
@@ -3,10 +3,10 @@
 
 #include "px_types.h"
 const char *captcha_type_str(captcha_type_t captcha_type);
-char *create_activity(const char *activity_type, const px_config *conf, const request_context *ctx);
-char *create_risk_payload(const request_context *ctx, const px_config *conf);
-char *create_mobile_response(px_config *cfg, request_context *ctx, const char *compiled_html);
-char *create_json_response(px_config *cfg, request_context *ctx);
+char *create_activity(const char *activity_type, const request_context *ctx);
+char *create_risk_payload(const request_context *ctx);
+char *create_mobile_response(request_context *ctx, const char *compiled_html);
+char *create_json_response(request_context *ctx);
 const char *get_call_reason_string(call_reason_t call_reason);
 
 risk_response* parse_risk_response(const char* risk_response_str, const request_context *ctx);

--- a/src/px_template.c
+++ b/src/px_template.c
@@ -179,7 +179,7 @@ const char* select_template(const px_config *conf, request_context *ctx) {
     const char *template_postfix = ctx->token_origin == TOKEN_ORIGIN_COOKIE ? "" : ".mobile"; // for mobile captcha
 
     // modify hosts according to first party
-    const char *jsClientSrc = conf->client_exteral_path;
+    // const char *jsClientSrc = conf->client_exteral_path;
     if (conf->first_party_enabled && ctx->token_origin == TOKEN_ORIGIN_COOKIE) {
         template_host = conf->captcha_path_prefix;
         host_url = conf->xhr_path_prefix;

--- a/src/px_types.h
+++ b/src/px_types.h
@@ -63,7 +63,7 @@ typedef struct px_config_t {
     apr_thread_mutex_t *health_check_cond_mutex;
     apr_thread_t *health_check_thread;
     apr_thread_cond_t *health_check_cond;
-    int px_errors_threshold;
+    apr_uint32_t px_errors_threshold;
     volatile apr_uint32_t px_errors_count;
     long health_check_interval; // in ms
     bool should_exit_thread;

--- a/src/px_utils.c
+++ b/src/px_utils.c
@@ -263,6 +263,8 @@ int extract_payload_from_header(apr_pool_t *pool, apr_table_t *headers, const ch
             case 3:
                 *payload3 = postfix;
                 break;
+            default:
+                return -1;
         }
         return version;
     }

--- a/src/px_utils.h
+++ b/src/px_utils.h
@@ -6,6 +6,12 @@
 #include <http_log.h>
 #include "px_types.h"
 
+#if defined(__GNUC__)
+#  define UNUSED __attribute__((__unused__))
+#else
+#  define UNUSED
+#endif
+
 struct response_t {
     char* data;
     size_t size;


### PR DESCRIPTION
* add `UNUSED` macro to suppress compiler warning
* remove `conf` functions arguments, as conf is present in `request_context` arguments
* rename `risk_payload` and `risk_response` as these variables shadow structure names
* add default cases to payload version checks
* disable unused code, other minor code improvements