### PR TITLE
Handle 304/204 responses without body

### DIFF
--- a/src/mod_perimeterx.c
+++ b/src/mod_perimeterx.c
@@ -247,7 +247,9 @@ static int px_handle_request(request_rec *r, px_config *conf) {
         redirect_res = redirect_client(r, conf);
         r->status = redirect_res->http_code;
         redirect_copy_headers_out(r, redirect_res);
-        ap_rwrite(redirect_res->content, redirect_res->content_size, r);
+        if (redirect_res->content_size) {
+            ap_rwrite(redirect_res->content, redirect_res->content_size, r);
+        }
         return DONE;
     }
 
@@ -256,7 +258,9 @@ static int px_handle_request(request_rec *r, px_config *conf) {
         redirect_res = redirect_xhr(r, conf);
         r->status = redirect_res->http_code;
         redirect_copy_headers_out(r, redirect_res);
-        ap_rwrite(redirect_res->content, redirect_res->content_size, r);
+        if (redirect_res->content_size) {
+            ap_rwrite(redirect_res->content, redirect_res->content_size, r);
+        }
         return DONE;
     }
 
@@ -1561,7 +1565,7 @@ static void *create_config(apr_pool_t *p, server_rec *s) {
         conf->origin_envvar_name  = NULL;
         conf->origin_wildcard_enabled = false;
         conf->captcha_type = CAPTCHA_TYPE_RECAPTCHA;
-        conf->monitor_mode = true; 
+        conf->monitor_mode = true;
         conf->enable_token_via_header = true;
         conf->captcha_subdomain = false;
         conf->first_party_enabled = true;


### PR DESCRIPTION
if PX server sends response with 304(not modified) or 204 (no content) - do not read body and send response without body back to a client with 304/204 HTTP code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/perimeterx/mod_perimeterx/183)
<!-- Reviewable:end -->
