### PR TITLE
Add custom parameters feature

### DIFF
--- a/src/mod_perimeterx.c
+++ b/src/mod_perimeterx.c
@@ -1513,7 +1513,6 @@ static const char* add_custom_parameters(cmd_parms *cmd, void *config, const cha
                     state = SPACE;
                     const char** entry = apr_array_push(conf->custom_parameters);
                     *entry = str_start;
-                    continue;
                 }
                 continue;
             case WORD:
@@ -1522,7 +1521,6 @@ static const char* add_custom_parameters(cmd_parms *cmd, void *config, const cha
                     state = SPACE;
                     const char** entry = apr_array_push(conf->custom_parameters);
                     *entry = str_start;
-                    continue;
                 }
                 continue;
         }

--- a/src/mod_perimeterx.c
+++ b/src/mod_perimeterx.c
@@ -1496,17 +1496,17 @@ static const char* add_custom_parameters(cmd_parms *cmd, void *config, const cha
         switch (state) {
             case SPACE:
                 if (isspace(c)) {
-                    continue;
+                    break;
                 }
                 if (c == '"') {
                     state = STRING;
                     str_start = p + 1;
-                    continue;
+                    break;
                 }
 
                 state = WORD;
                 str_start = p;
-                continue;
+                break;
             case STRING:
                 if (c == '"') {
                     *p = '\0';
@@ -1514,7 +1514,7 @@ static const char* add_custom_parameters(cmd_parms *cmd, void *config, const cha
                     const char** entry = apr_array_push(conf->custom_parameters);
                     *entry = str_start;
                 }
-                continue;
+                break;
             case WORD:
                 if (isspace(c)) {
                     *p = '\0';
@@ -1522,10 +1522,9 @@ static const char* add_custom_parameters(cmd_parms *cmd, void *config, const cha
                     const char** entry = apr_array_push(conf->custom_parameters);
                     *entry = str_start;
                 }
-                continue;
+                break;
         }
     }
-
 
     // if the state is WORD: handle the last word in the list
     if (state == WORD) {

--- a/src/mod_perimeterx.c
+++ b/src/mod_perimeterx.c
@@ -1526,9 +1526,20 @@ static const char* add_custom_parameters(cmd_parms *cmd, void *config, const cha
         }
     }
 
+
+    // if the state is WORD: handle the last word in the list
+    if (state == WORD) {
+        const char** entry = apr_array_push(conf->custom_parameters);
+        *entry = str_start;
+    }
+
+    // if the state is STRING: report error, there were no ending quotes
+    if (state == STRING) {
+        ap_log_perror(APLOG_MARK, APLOG_ERR, APR_SUCCESS, cmd->pool, "Error processing px_custom_parameters directive");
+    }
+
     return NULL;
 }
-
 
 
 static int px_hook_post_request(request_rec *r) {

--- a/src/px_types.h
+++ b/src/px_types.h
@@ -99,6 +99,7 @@ typedef struct px_config_t {
     int px_debug;
     int log_level_err;
     int log_level_debug;
+    apr_array_header_t *custom_parameters;
 } px_config;
 
 typedef struct thread_data_t {


### PR DESCRIPTION
Custom parameters keys are set in `px_custom_parameters` conf parameter (separated by comma).
Map custom parameters headers to custom_param[1-10] keys for RiskAPI and activity JSON objects.