### PR TITLE
Fix HMAC functions for older OpenSSL versions

### DIFF
--- a/src/px_payload.c
+++ b/src/px_payload.c
@@ -4,7 +4,6 @@
 #include <openssl/evp.h>
 #include <openssl/bio.h>
 #include <openssl/sha.h>
-#include <openssl/hmac.h>
 
 #include <jansson.h>
 #include <apr_base64.h>
@@ -25,25 +24,6 @@ static const int HASH_LEN = 65;
 
 static const char *SIGNING_NOFIELDS[] = { NULL };
 static const char *COOKIE_DELIMITER = ":";
-
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
-static HMAC_CTX *HMAC_CTX_new(void)
-{
-   HMAC_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
-   if (ctx != NULL) {
-       HMAC_CTX_init(ctx);
-   }
-   return ctx;
-}
-
-static void HMAC_CTX_free(HMAC_CTX *ctx)
-{
-   if (ctx != NULL) {
-       HMAC_CTX_cleanup(ctx);
-       OPENSSL_free(ctx);
-   }
-}
-#endif
 
 static unsigned char *decode_base64(const char *s, int *len, apr_pool_t *p) {
     if (!s) {

--- a/src/px_utils.c
+++ b/src/px_utils.c
@@ -4,7 +4,6 @@
 
 #include <arpa/inet.h>
 #include <apr_strings.h>
-#include <openssl/hmac.h>
 
 #ifdef APLOG_USE_MODULE
 APLOG_USE_MODULE(perimeterx);
@@ -507,6 +506,26 @@ void px_log(const px_config *conf, apr_pool_t *pool, bool log_debug, int level, 
         log_debug ? LOGGER_DEBUG_HDR: LOGGER_ERROR_HDR,
         conf->app_id, func, text);
 }
+
+// older OpenSSL versions do not have these functions
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+HMAC_CTX *HMAC_CTX_new(void)
+{
+   HMAC_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));
+   if (ctx != NULL) {
+       HMAC_CTX_init(ctx);
+   }
+   return ctx;
+}
+
+void HMAC_CTX_free(HMAC_CTX *ctx)
+{
+   if (ctx != NULL) {
+       HMAC_CTX_cleanup(ctx);
+       OPENSSL_free(ctx);
+   }
+}
+#endif
 
 // generate HMAC SHA256 for str
 // return true if signature is set

--- a/src/px_utils.h
+++ b/src/px_utils.h
@@ -4,6 +4,7 @@
 #include <http_protocol.h>
 #include <apr_pools.h>
 #include <http_log.h>
+#include <openssl/hmac.h>
 #include "px_types.h"
 
 #if defined(__GNUC__)
@@ -30,6 +31,13 @@ CURLcode redirect_helper(CURL* curl, const char *base_url, const char *uri, cons
 size_t write_response_cb(void* contents, size_t size, size_t nmemb, void *stream);
 size_t write_response_pool_cb(void* contents, size_t size, size_t nmemb, void *stream);
 void update_and_notify_health_check(px_config *conf);
+
+
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+HMAC_CTX *HMAC_CTX_new(void);
+void HMAC_CTX_free(HMAC_CTX *ctx);
+#endif
+
 bool px_hmac_str(const char *key, const char *str, char *signature, int signature_len);
 
 /* Logging */


### PR DESCRIPTION
`HMAC_CTX_new()` and `HMAC_CTX_free()` functions are not present in older OpenSSL versions.